### PR TITLE
allow usage of a custom GitLab URL

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+# 0.2.1
+
+- Add custom GitLab URL setting
+
 # 0.2.0
 
 - #8 - Fully automated! Use new gitlab API for the last step

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ gitlab-letsencrypt:
   delay_time:     15 # How long to wait between each check once it starts looking for the file
 
   # Optional settings you probably don't need:
+  gitlab_url:            'https://someurl' # Set if you need to use a self-hosted GitLab instance
   endpoint:  'https://somewhere' # if you're doing the ACME thing outside of letsencrypt
   branch:    'master'            # Defaults to master, but you can use a different branch
   layout:    'null'              # Layout to use for challenge file - defaults to null, but you can change if needed

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ gitlab-letsencrypt:
   delay_time:     15 # How long to wait between each check once it starts looking for the file
 
   # Optional settings you probably don't need:
-  gitlab_url:            'https://someurl' # Set if you need to use a self-hosted GitLab instance
+  gitlab_url: 'https://someurl'  # Set if you need to use a self-hosted GitLab instance
   endpoint:  'https://somewhere' # if you're doing the ACME thing outside of letsencrypt
   branch:    'master'            # Defaults to master, but you can use a different branch
   layout:    'null'              # Layout to use for challenge file - defaults to null, but you can change if needed

--- a/lib/jekyll/gitlab/letsencrypt/configuration.rb
+++ b/lib/jekyll/gitlab/letsencrypt/configuration.rb
@@ -12,6 +12,7 @@ module Jekyll
         DEFAULT_INITIAL_DELAY   = 120
         DEFAULT_DELAY_TIME      = 15
         DEFAULT_SCHEME          = 'http'
+        DEFAULT_GITLAB_URL      = 'https://gitlab.com'
 
         REQUIRED_KEYS = %w{gitlab_repo email domain}
 
@@ -23,6 +24,10 @@ module Jekyll
 
           def endpoint
             jekyll_config['endpoint'] || DEFAULT_ENDPOINT
+          end
+
+          def gitlab_url
+            jekyll_config['gitlab_url'] || DEFAULT_GITLAB_URL
           end
 
           def gitlab_repo

--- a/lib/jekyll/gitlab/letsencrypt/gitlab_client.rb
+++ b/lib/jekyll/gitlab/letsencrypt/gitlab_client.rb
@@ -7,7 +7,7 @@ module Jekyll
 
         attr_accessor :content
 
-        delegate :filename, :personal_access_token, :gitlab_repo, :branch, :domain, to: Configuration
+        delegate :filename, :personal_access_token, :gitlab_url, :gitlab_repo, :branch, :domain, to: Configuration
 
         def commit!(content)
           @content = content
@@ -49,7 +49,7 @@ module Jekyll
               content:        content
             }.to_json
           end
-          Jekyll.logger.info "Done Commiting! Check https://gitlab.com/#{gitlab_repo}/commits/#{branch}"
+          Jekyll.logger.info "Done Commiting! Check #{gitlab_url}/#{gitlab_repo}/commits/#{branch}"
         end
 
       private
@@ -73,7 +73,7 @@ module Jekyll
         end
 
         def connection
-          @connection ||= Faraday.new(url: 'https://gitlab.com/api/v3/') do |faraday|
+          @connection ||= Faraday.new(url: "#{gitlab_url}/api/v3/") do |faraday|
             faraday.adapter Faraday.default_adapter
             faraday.headers['Content-Type']  = 'application/json'
             faraday.headers['PRIVATE-TOKEN'] = personal_access_token

--- a/lib/jekyll/gitlab/letsencrypt/process.rb
+++ b/lib/jekyll/gitlab/letsencrypt/process.rb
@@ -84,7 +84,7 @@ module Jekyll
 
         def display_certificate
           Jekyll.logger.info "Certifcate retrieved!"
-          Jekyll.logger.info "Go to https://gitlab.com/#{gitlab_repo}/pages"
+          Jekyll.logger.info "Go to #{gitlab_url}/#{gitlab_repo}/pages"
           Jekyll.logger.info " - If you already have an existing entry for #{domain}, remove it"
           Jekyll.logger.info " - Then click + New Domain and enter the following:"
           Jekyll.logger.info ""

--- a/lib/jekyll/gitlab/letsencrypt/process.rb
+++ b/lib/jekyll/gitlab/letsencrypt/process.rb
@@ -12,7 +12,7 @@ module Jekyll
           self.new(client).process!
         end
 
-        delegate :base_path, :gitlab_repo, :pretty_url?, :layout, :domain, :initial_delay, :delay_time, :scheme, to: Configuration
+        delegate :base_path, :gitlab_url, :gitlab_repo, :pretty_url?, :layout, :domain, :initial_delay, :delay_time, :scheme, to: Configuration
 
         def initialize(client)
           @client = client

--- a/lib/jekyll/gitlab/letsencrypt/version.rb
+++ b/lib/jekyll/gitlab/letsencrypt/version.rb
@@ -1,7 +1,7 @@
 module Jekyll
   module Gitlab
     module Letsencrypt
-      VERSION = "0.2.0"
+      VERSION = "0.2.1"
     end
   end
 end

--- a/spec/lib/jekyll/gitlab/letsencrypt/configuration_spec.rb
+++ b/spec/lib/jekyll/gitlab/letsencrypt/configuration_spec.rb
@@ -59,4 +59,16 @@ describe Jekyll::Gitlab::Letsencrypt::Configuration do
       it { should eq 'https://foo/'}
     end
   end
+
+  describe '#gitlab_url' do
+    subject { described_class.gitlab_url }
+    context "with no gitlab_url" do
+      it { should eq 'https://gitlab.com'}
+    end
+
+    context "with an gitlab_url" do
+      let(:plugin_config) { {'gitlab_url' => "https://gitlab"} }
+      it { should eq 'https://gitlab'}
+    end
+  end
 end

--- a/spec/lib/jekyll/gitlab/letsencrypt/gitlab_client_spec.rb
+++ b/spec/lib/jekyll/gitlab/letsencrypt/gitlab_client_spec.rb
@@ -6,6 +6,7 @@ describe Jekyll::Gitlab::Letsencrypt::GitlabClient do
 
   let(:filename)              { 'test_file.html' }
   let(:personal_access_token) { 'SECRET_TOKEN' }
+  let(:gitlab_url)            { 'https://gitlab.com'}
   let(:gitlab_repo)           { 'gitlab_user/gitlab_repo' }
   let(:branch)                { 'test_branch' }
   let(:domain)                { 'example.com' }


### PR DESCRIPTION
This PR will add the ability to set a custom GitLab instance in `_config.yml` if you happen to be using Pages in a self-hosted environment.

This is pretty much my first contribution to a Ruby gem, so I welcome any feedback on making it better.