### PR TITLE
Check for repo id fetch request status

### DIFF
--- a/lib/jekyll/gitlab/letsencrypt/gitlab_client.rb
+++ b/lib/jekyll/gitlab/letsencrypt/gitlab_client.rb
@@ -68,6 +68,9 @@ module Jekyll
           @repo_id ||= begin
             repo_name = gitlab_repo.gsub "/", "%2f"
             response  = connection.get "projects/#{repo_name}"
+            unless response.success?
+              fail StandardError, "Failed response for projects/#{repo_name}. Please check if personall token and repo name are correct"
+            end
             JSON.parse(response.body)['id']
           end
         end

--- a/spec/lib/jekyll/gitlab/letsencrypt/gitlab_client_spec.rb
+++ b/spec/lib/jekyll/gitlab/letsencrypt/gitlab_client_spec.rb
@@ -54,4 +54,29 @@ describe Jekyll::Gitlab::Letsencrypt::GitlabClient do
       end
     end
   end
+
+  describe "#repo_id" do
+    let(:mock_connection) { double Faraday::Connection, get: response}
+
+    before do
+      allow(gitlab_client).to receive(:connection).and_return mock_connection
+    end
+
+    context "unsuccessful" do
+      let(:response) { double Faraday::Response, success?: false }
+
+      it "raises" do
+          expect { gitlab_client.send(:repo_id) }
+            .to raise_error(StandardError, /Failed response for projects.*/)
+      end
+    end
+
+    context 'successful' do
+      let(:response) { double Faraday::Response, success?: true, body: '{ "id": 123 }' }
+
+      it "returns repo_id" do
+          expect(gitlab_client.send(:repo_id)).to eq 123
+      end
+    end
+  end
 end


### PR DESCRIPTION
Basically this is fast check of Gitlab connectivity. If either repo or token is invalid, this will raise instead of going further. Going further will fail on pulling branch status, with hard to read trace.