### PR TITLE
Update API calls to v4

### DIFF
--- a/lib/jekyll/gitlab/letsencrypt/gitlab_client.rb
+++ b/lib/jekyll/gitlab/letsencrypt/gitlab_client.rb
@@ -40,7 +40,7 @@ module Jekyll
 
         def commit_file!
           Jekyll.logger.info "Commiting challenge file as #{filename}"
-          enc_filename = filename.gsub "/", "%2f"
+          enc_filename = filename.gsub("/", "%2f").gsub(".", "%2e")
           connection.run_request(request_method_for_commit, nil, nil, nil) do |req|
             req.url        "projects/#{repo_id}/repository/files/#{enc_filename}"
             req.body = {
@@ -60,7 +60,7 @@ module Jekyll
         end
 
         def request_method_for_commit
-          enc_filename = filename.gsub "/", "%2f"
+          enc_filename = filename.gsub("/", "%2f").gsub(".", "%2e")
           response = connection.get "projects/#{repo_id}/repository/files/#{enc_filename}?ref=#{branch}"
           response.status == 404 ? :post : :put
         end

--- a/lib/jekyll/gitlab/letsencrypt/gitlab_client.rb
+++ b/lib/jekyll/gitlab/letsencrypt/gitlab_client.rb
@@ -40,7 +40,7 @@ module Jekyll
 
         def commit_file!
           Jekyll.logger.info "Commiting challenge file as #{filename}"
-          enc_filename = filename.gsub("/", "%2f").gsub(".", "%2e")
+          enc_filename = filename.gsub "/", "%2f"
           connection.run_request(request_method_for_commit, nil, nil, nil) do |req|
             req.url        "projects/#{repo_id}/repository/files/#{enc_filename}"
             req.body = {
@@ -60,7 +60,7 @@ module Jekyll
         end
 
         def request_method_for_commit
-          enc_filename = filename.gsub("/", "%2f").gsub(".", "%2e")
+          enc_filename = filename.gsub "/", "%2f"
           response = connection.get "projects/#{repo_id}/repository/files/#{enc_filename}?ref=#{branch}"
           response.status == 404 ? :post : :put
         end

--- a/lib/jekyll/gitlab/letsencrypt/gitlab_client.rb
+++ b/lib/jekyll/gitlab/letsencrypt/gitlab_client.rb
@@ -40,10 +40,10 @@ module Jekyll
 
         def commit_file!
           Jekyll.logger.info "Commiting challenge file as #{filename}"
+          enc_filename = filename.gsub "/", "%2f"
           connection.run_request(request_method_for_commit, nil, nil, nil) do |req|
-            req.url        "projects/#{repo_id}/repository/files"
+            req.url        "projects/#{repo_id}/repository/files/#{enc_filename}"
             req.body = {
-              file_path:      filename,
               commit_message: "Automated Let's Encrypt renewal",
               branch_name:    branch,
               content:        content
@@ -60,7 +60,8 @@ module Jekyll
         end
 
         def request_method_for_commit
-          response = connection.get "projects/#{repo_id}/repository/files?ref=#{branch}&file_path=#{filename}"
+          enc_filename = filename.gsub "/", "%2f"
+          response = connection.get "projects/#{repo_id}/repository/files/#{enc_filename}?ref=#{branch}"
           response.status == 404 ? :post : :put
         end
 
@@ -73,7 +74,7 @@ module Jekyll
         end
 
         def connection
-          @connection ||= Faraday.new(url: "#{gitlab_url}/api/v3/") do |faraday|
+          @connection ||= Faraday.new(url: "#{gitlab_url}/api/v4/") do |faraday|
             faraday.adapter Faraday.default_adapter
             faraday.headers['Content-Type']  = 'application/json'
             faraday.headers['PRIVATE-TOKEN'] = personal_access_token

--- a/spec/fixtures/vcr_cassettes/gitlab_commit.yml
+++ b/spec/fixtures/vcr_cassettes/gitlab_commit.yml
@@ -146,7 +146,7 @@ http_interactions:
   recorded_at: Tue, 07 Feb 2017 23:31:54 GMT
 - request:
     method: get
-    uri: https://gitlab.com/api/v4/projects/1234/repository/files/test_file%2ehtml?ref=test_branch
+    uri: https://gitlab.com/api/v4/projects/1234/repository/files/test_file.html?ref=test_branch
     body:
       encoding: US-ASCII
       string: ''
@@ -192,7 +192,7 @@ http_interactions:
   recorded_at: Tue, 07 Feb 2017 23:31:55 GMT
 - request:
     method: post
-    uri: https://gitlab.com/api/v3/projects/1234/repository/files/test_file%2ehtml
+    uri: https://gitlab.com/api/v4/projects/1234/repository/files/test_file.html
     body:
       encoding: UTF-8
       string: '{"commit_message":"Automated Let''s Encrypt

--- a/spec/fixtures/vcr_cassettes/gitlab_commit.yml
+++ b/spec/fixtures/vcr_cassettes/gitlab_commit.yml
@@ -146,7 +146,7 @@ http_interactions:
   recorded_at: Tue, 07 Feb 2017 23:31:54 GMT
 - request:
     method: get
-    uri: https://gitlab.com/api/v4/projects/1234/repository/files/test_file.html?ref=test_branch
+    uri: https://gitlab.com/api/v4/projects/1234/repository/files/test_file%2ehtml?ref=test_branch
     body:
       encoding: US-ASCII
       string: ''
@@ -192,7 +192,7 @@ http_interactions:
   recorded_at: Tue, 07 Feb 2017 23:31:55 GMT
 - request:
     method: post
-    uri: https://gitlab.com/api/v3/projects/1234/repository/files/test_file.html
+    uri: https://gitlab.com/api/v3/projects/1234/repository/files/test_file%2ehtml
     body:
       encoding: UTF-8
       string: '{"commit_message":"Automated Let''s Encrypt

--- a/spec/fixtures/vcr_cassettes/gitlab_commit.yml
+++ b/spec/fixtures/vcr_cassettes/gitlab_commit.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://gitlab.com/api/v3/projects/gitlab_user%2fgitlab_repo
+    uri: https://gitlab.com/api/v4/projects/gitlab_user%2fgitlab_repo
     body:
       encoding: US-ASCII
       string: ''
@@ -50,7 +50,7 @@ http_interactions:
   recorded_at: Tue, 07 Feb 2017 23:31:52 GMT
 - request:
     method: get
-    uri: https://gitlab.com/api/v3/projects/1234/repository/branches
+    uri: https://gitlab.com/api/v4/projects/1234/repository/branches
     body:
       encoding: US-ASCII
       string: ''
@@ -98,7 +98,7 @@ http_interactions:
   recorded_at: Tue, 07 Feb 2017 23:31:52 GMT
 - request:
     method: post
-    uri: https://gitlab.com/api/v3/projects/1234/repository/branches
+    uri: https://gitlab.com/api/v4/projects/1234/repository/branches
     body:
       encoding: UTF-8
       string: '{"branch_name":"test_branch","ref":"master"}'
@@ -146,7 +146,7 @@ http_interactions:
   recorded_at: Tue, 07 Feb 2017 23:31:54 GMT
 - request:
     method: get
-    uri: https://gitlab.com/api/v3/projects/1234/repository/files?file_path=test_file.html&ref=test_branch
+    uri: https://gitlab.com/api/v4/projects/1234/repository/files/test_file.html?ref=test_branch
     body:
       encoding: US-ASCII
       string: ''
@@ -192,10 +192,10 @@ http_interactions:
   recorded_at: Tue, 07 Feb 2017 23:31:55 GMT
 - request:
     method: post
-    uri: https://gitlab.com/api/v3/projects/1234/repository/files
+    uri: https://gitlab.com/api/v3/projects/1234/repository/files/test_file.html
     body:
       encoding: UTF-8
-      string: '{"file_path":"test_file.html","commit_message":"Automated Let''s Encrypt
+      string: '{"commit_message":"Automated Let''s Encrypt
         renewal","branch_name":"test_branch","content":"<CONTENT>"}'
     headers:
       Content-Type:


### PR DESCRIPTION
GitLab API v3 isn't supported anymore, so the API calls must be updated to API v4.