### PR TITLE
Add commit message configuration option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ rvm:
   - 2.1
   - 2.2.0
   - 2.3.3
-before_install: gem install bundler --pre
+before_install: gem install bundler -v 1.17.1

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ gitlab-letsencrypt:
   branch:    'master'            # Defaults to master, but you can use a different branch
   layout:    'null'              # Layout to use for challenge file - defaults to null, but you can change if needed
   scheme:    'https'             # Scheme to use for challenge request; default http
+  commit_message: 'Renew certificate [ROBOT]'  # Commit message to use; defaults to "Automated Let's Encrypt renewal"
 ```
 
 ### Running

--- a/lib/jekyll/gitlab/letsencrypt/configuration.rb
+++ b/lib/jekyll/gitlab/letsencrypt/configuration.rb
@@ -13,6 +13,7 @@ module Jekyll
         DEFAULT_DELAY_TIME      = 15
         DEFAULT_SCHEME          = 'http'
         DEFAULT_GITLAB_URL      = 'https://gitlab.com'
+	DEFAULT_COMMIT_MESSAGE  = "Automated Let's Encrypt renewal"
 
         REQUIRED_KEYS = %w{gitlab_repo email domain}
 
@@ -84,6 +85,10 @@ module Jekyll
 
           def jekyll_config
             @jekyll_config ||= (Jekyll.configuration({})['gitlab-letsencrypt'] || {})
+          end
+
+          def commit_message
+            jekyll_config['commit_message'] || DEFAULT_COMMIT_MESSAGE
           end
         end
       end

--- a/lib/jekyll/gitlab/letsencrypt/configuration.rb
+++ b/lib/jekyll/gitlab/letsencrypt/configuration.rb
@@ -13,7 +13,7 @@ module Jekyll
         DEFAULT_DELAY_TIME      = 15
         DEFAULT_SCHEME          = 'http'
         DEFAULT_GITLAB_URL      = 'https://gitlab.com'
-	DEFAULT_COMMIT_MESSAGE  = "Automated Let's Encrypt renewal"
+        DEFAULT_COMMIT_MESSAGE  = "Automated Let's Encrypt renewal"
 
         REQUIRED_KEYS = %w{gitlab_repo email domain}
 

--- a/lib/jekyll/gitlab/letsencrypt/gitlab_client.rb
+++ b/lib/jekyll/gitlab/letsencrypt/gitlab_client.rb
@@ -7,7 +7,7 @@ module Jekyll
 
         attr_accessor :content
 
-        delegate :filename, :personal_access_token, :gitlab_url, :gitlab_repo, :branch, :domain, to: Configuration
+        delegate :filename, :personal_access_token, :gitlab_url, :gitlab_repo, :branch, :domain, :commit_message, to: Configuration
 
         def commit!(content)
           @content = content
@@ -43,7 +43,7 @@ module Jekyll
           connection.run_request(request_method_for_commit, nil, nil, nil) do |req|
             req.url        "projects/#{repo_id}/repository/files/#{enc_filename}"
             req.body = {
-              commit_message: "Automated Let's Encrypt renewal",
+              commit_message: commit_message,
               branch:         branch,
               content:        content
             }.to_json

--- a/spec/lib/jekyll/gitlab/letsencrypt/configuration_spec.rb
+++ b/spec/lib/jekyll/gitlab/letsencrypt/configuration_spec.rb
@@ -71,4 +71,16 @@ describe Jekyll::Gitlab::Letsencrypt::Configuration do
       it { should eq 'https://gitlab'}
     end
   end
+
+  describe '#commit_message' do
+    subject { described_class.commit_message }
+    context "with no commit_message" do
+      it { should eq 'Automated Let\'s Encrypt renewal' }
+    end
+
+    context "with a commit_message" do
+      let(:plugin_config) { {'commit_message' => "Renew Let's Encrypt Certificate" } }
+      it { should eq "Renew Let's Encrypt Certificate" } 
+    end
+  end
 end


### PR DESCRIPTION
Some users may want to add an additional marker tag for automated code commits, others may want to use imperative style commit messages (as outlined in https://chris.beams.io/posts/git-commit/). 

With adding the commit message configuration option both groups of users can now do as they please in an easy manner.