### PR TITLE
fixes challenge url and makes email configurable by environment varia…

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+# 0.4.2
+  - #24 - Changes URL extension.
+        - Makes email configurable via environment variable.
+
 # 0.4.1
   - #23 - Add option to append arbitrary text to the challenge file
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ gitlab-letsencrypt:
 
   # Jekyll settings:
   base_path:  './'               # Where you want the file to go
-  pretty_url: false              # Add a "/" on the end of the URL... set to `true` if you use permalink_style: pretty
+  pretty_url: false              # Add a ".html" on the end of the URL... set to `true` if you use permalink_style: pretty
   append_str: ''                 # Append this string to the end of the challenge URL
   filename:   'letsencrypt.html' # What to call the generated challenge file
 

--- a/jekyll-gitlab-letsencrypt.gemspec
+++ b/jekyll-gitlab-letsencrypt.gemspec
@@ -5,12 +5,12 @@ require 'jekyll/gitlab/letsencrypt/version'
 Gem::Specification.new do |spec|
   spec.name          = "jekyll-gitlab-letsencrypt"
   spec.version       = Jekyll::Gitlab::Letsencrypt::VERSION
-  spec.authors       = ["Justin Aiken"]
+  spec.authors       = ["Justin Aiken", "Carlos Asmat"]
   spec.email         = ["60tonangel@gmail.com"]
 
   spec.summary       = %q{Automate letsencrypt renewals for gitlab pages.}
   spec.description   = %q{Automate letsencrypt renewals for gitlab pages.}
-  spec.homepage      = "https://github.com/JustinAiken/jekyll-gitlab-letsencrypt"
+  spec.homepage      = "https://github.com/Sotilrac/jekyll-gitlab-letsencrypt"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match %r{^(spec)/} }

--- a/lib/jekyll/gitlab/letsencrypt/configuration.rb
+++ b/lib/jekyll/gitlab/letsencrypt/configuration.rb
@@ -56,7 +56,7 @@ module Jekyll
           end
 
           def email
-            jekyll_config['email']
+            jekyll_config['email'].presence || ENV['EMAIL'].presence
           end
 
           def domain

--- a/lib/jekyll/gitlab/letsencrypt/process.rb
+++ b/lib/jekyll/gitlab/letsencrypt/process.rb
@@ -106,7 +106,7 @@ module Jekyll
           permalink  = ""
           permalink += base_path if base_path
           permalink += challenge.filename
-          permalink += "/" if pretty_url?
+          permalink += ".html" if pretty_url?
           permalink += append_str
 
           content  = "---\n"
@@ -124,7 +124,6 @@ module Jekyll
           @challenge_url ||= begin
             url  = "#{scheme}://#{domain}/"
             url += challenge.filename
-            url += "/" if pretty_url?
             url
           end
         end

--- a/lib/jekyll/gitlab/letsencrypt/version.rb
+++ b/lib/jekyll/gitlab/letsencrypt/version.rb
@@ -1,7 +1,7 @@
 module Jekyll
   module Gitlab
     module Letsencrypt
-      VERSION = "0.4.1"
+      VERSION = "0.4.2"
     end
   end
 end


### PR DESCRIPTION
Gitlab Jekyll CI cannot generate pages without an extension anymore. This addresses this issue and makes the email address configurable by env variable in order to prevent it from being exposed to the public.

Feel free to take the changes or modify them as you see fit.

Thanks for the gem. It's very useful!